### PR TITLE
Treat carriage return as white-space

### DIFF
--- a/tinyscript.c
+++ b/tinyscript.c
@@ -296,7 +296,7 @@ static int charin(int c, const char *str)
 // drag in a table of character flags
 static int isspace(int c)
 {
-    return (c == ' ') || (c == '\t');
+    return (c == ' ') || (c == '\t') || (c == '\r');
 }
 
 static int isdigit(int c)


### PR DESCRIPTION
Treat carriage return as white-space in order to handle Windows CRLF line endings.