### PR TITLE
Improve verbose errors

### DIFF
--- a/tinyscript.c
+++ b/tinyscript.c
@@ -54,6 +54,10 @@ static Sym *symptr;
 static Val *valptr;
 static String parseptr;  // acts as instruction pointer
 
+#ifdef VERBOSE_ERRORS
+static const char *script_buffer;
+#endif
+
 // arguments to functions
 static Val fArgs[MAX_BUILTIN_PARAMS];
 static Val fResult = 0;
@@ -178,22 +182,18 @@ static int charin(int c, const char *str)
 // some functions to print an error and return
 //
 static void ErrorAt() {
-    // skip leading white-space
     const char* ptr = StringGetPtr(parseptr);
-    while (*ptr && charin(*ptr, " \t\r\n")) {
-        ptr++;
+	// back up to beginning of statement
+    while (ptr > script_buffer && !charin(*(ptr - 1), ";\n")) {
+        ptr--;
     }
-    if (!*ptr) {
-        outcstr(" in last statement\n");
-    } else {
-        outcstr(" before: ");
-        // print until end of statement
-        while (*ptr && !charin(*ptr, ";\n")) {
-            outchar(*ptr);
-            ptr++;
-        }
-        outchar('\n');
-    }
+	outcstr(" in: ");
+	// print until end of statement
+	while (*ptr && !charin(*ptr, ";\n")) {
+		outchar(*ptr);
+		ptr++;
+	}
+	outchar('\n');
 }
 static int SyntaxError() {
     outcstr("syntax error");
@@ -1169,5 +1169,8 @@ TinyScript_Init(void *mem, int mem_size)
 int
 TinyScript_Run(const char *buf, int saveStrings, int topLevel)
 {
+#ifdef VERBOSE_ERRORS
+    script_buffer = buf;
+#endif
     return ParseString(Cstring(buf), saveStrings, topLevel);
 }

--- a/tinyscript.c
+++ b/tinyscript.c
@@ -164,26 +164,55 @@ outcstr(const char *ptr)
     }
 }
 
+// return true if a character is in a string
+static int charin(int c, const char *str)
+{
+    while (*str) {
+        if (c == *str++) return 1;
+    }
+    return 0;
+}
+
 #ifdef VERBOSE_ERRORS
 //
 // some functions to print an error and return
 //
+static void ErrorAt() {
+    // skip leading white-space
+    const char* ptr = StringGetPtr(parseptr);
+    while (*ptr && charin(*ptr, " \t\r\n")) {
+        ptr++;
+    }
+    if (!*ptr) {
+        outcstr(" in last statement\n");
+    } else {
+        outcstr(" before: ");
+        // print until end of statement
+        while (*ptr && !charin(*ptr, ";\n")) {
+            outchar(*ptr);
+            ptr++;
+        }
+        outchar('\n');
+    }
+}
 static int SyntaxError() {
-    outcstr("syntax error before:");
-    PrintString(parseptr);
-    outchar('\n');
+    outcstr("syntax error");
+    ErrorAt();
     return TS_ERR_SYNTAX;
 }
 static int ArgMismatch() {
-    outcstr("argument mismatch\n");
+    outcstr("argument mismatch");
+    ErrorAt();
     return TS_ERR_BADARGS;
 }
 static int TooManyArgs() {
-    outcstr("too many arguments\n");
+    outcstr("too many arguments");
+    ErrorAt();
     return TS_ERR_TOOMANYARGS;
 }
 static int OutOfMem() {
-    outcstr("out of memory\n");
+    outcstr("out of memory");
+    ErrorAt();
     return TS_ERR_NOMEM;
 }
 static int UnknownSymbol() {
@@ -280,15 +309,6 @@ UngetChar()
     StringSetLen(&parseptr, StringGetLen(parseptr)+1);
     StringSetPtr(&parseptr, StringGetPtr(parseptr)-1);
     IgnoreLastChar();
-}
-
-// return true if a character is in a string
-static int charin(int c, const char *str)
-{
-    while (*str) {
-        if (c == *str++) return 1;
-    }
-    return 0;
 }
 
 // these appear in <ctypes.h> too, but


### PR DESCRIPTION
This PR improves verbose error messages by printing only the full statement in which the error occurred, as opposed to printing from after the error location to the end of the entire script.