### PR TITLE
remove declaration of inchar

### DIFF
--- a/tinyscript.h
+++ b/tinyscript.h
@@ -95,7 +95,6 @@ int TinyScript_Define(const char *name, int toktype, Val value);
 int TinyScript_Run(const char *s, int saveStrings, int topLevel);
 
 // provided by our caller
-extern int inchar(void);
 extern void outchar(int c);
 
 #endif


### PR DESCRIPTION
inchar should not be declared in tinyscript.h because it is not defined or used in tinyscript.c

It is used in tstest, but removing it from tinyscript.h does not cause any error.
