### PR TITLE
allow numbers in identifiers

### DIFF
--- a/tinyscript.c
+++ b/tinyscript.c
@@ -361,7 +361,7 @@ static int isidpunct(int c)
 }
 static int isidentifier(int c)
 {
-    return isalpha(c) || isidpunct(c);
+    return isalpha(c) || isdigit(c) || isidpunct(c);
 }
 
 static int notquote(int c)


### PR DESCRIPTION
This PR allows numbers in an identifier. Since `doNextToken `already checks that the first character `isalpha`, adding `isdigit `to `isidentifier` only allows digits after the first alphanumeric character.