### PR TITLE
fix unary operator

### DIFF
--- a/tinyscript.c
+++ b/tinyscript.c
@@ -380,13 +380,15 @@ GetSpan(int (*testfn)(int))
         UngetChar();
     }
 }
-static int
-isoperatorchar2(int c) {
-    return charin(c, "=<>");
-}
+
 static int
 isoperator(int c) {
     return charin(c, "+-!/*%=<>&|^");
+}
+
+static int
+isoperatorchar2(int c) {
+    return charin(c, "=<>");
 }
 
 static int

--- a/tinyscript.c
+++ b/tinyscript.c
@@ -381,8 +381,12 @@ GetSpan(int (*testfn)(int))
     }
 }
 static int
+isoperatorchar2(int c) {
+    return charin(c, "=<>");
+}
+static int
 isoperator(int c) {
-    return charin(c, "+-/*%=<>&|^");
+    return charin(c, "+-!/*%=<>&|^");
 }
 
 static int
@@ -452,7 +456,7 @@ doNextToken(int israw)
             }
         }
     } else if (isoperator(c)) {
-        GetSpan(isoperator);
+        GetSpan(isoperatorchar2);
         tokenSym = sym = LookupSym(token);
         if (sym) {
             r = sym->type;
@@ -770,10 +774,9 @@ ParsePrimary(Val *vp)
         NextToken();
         return err;
     } else if ( (c & 0xff) == TOK_BINOP ) {
-        // binary operator
+        // unary operator
         Opfunc op = (Opfunc)tokenVal;
         Val v;
-        
         NextToken();
         err = ParseExpr(&v);
         if (err == TS_ERR_OK) {
@@ -1302,6 +1305,7 @@ static struct def {
     { "%",     BINOP(1), (intptr_t)mod },
     { "+",     BINOP(2), (intptr_t)sum },
     { "-",     BINOP(2), (intptr_t)diff },
+    { "!",     BINOP(2), (intptr_t)equals },
     { "&",     BINOP(3), (intptr_t)bitand },
     { "|",     BINOP(3), (intptr_t)bitor },
     { "^",     BINOP(3), (intptr_t)bitxor },


### PR DESCRIPTION
The required space before a unary minus has been vexing me. This change only allows two character operators if the second character is =, <, or >. That fixes it because before, something like a*-b would interpret *- as one operator.

This also allows for an (almost) free logical not operator by using the equals function to compare a number to zero.

A further minor improvement would be to check for valid unary operators (+, -, !) before calling `op(0, v)` and raise a syntax error on invalid characters.