### PR TITLE
fix return inside while

### DIFF
--- a/tinyscript.c
+++ b/tinyscript.c
@@ -1141,7 +1141,7 @@ ParseWhile()
 
 again:
     err = ParseIf();
-    if (err == TS_ERR_OK_ELSE) {
+    if (err == TS_ERR_OK_ELSE || didReturn) {
         return TS_ERR_OK;
     } else if (err == TS_ERR_OK) {
         parseptr = savepc;


### PR DESCRIPTION
This PR fixes a return inside of a while, like the example below, getting stuck in an endless loop.

```
func a(){
 while 1{
  print "a"
  return 1
 }
}

a()
```