### PR TITLE
Pass an array to a func

### DIFF
--- a/Test/array.expect
+++ b/Test/array.expect
@@ -4,6 +4,7 @@ x: 1, 2, 3
 x: 4, 5, 6
 y: 12, 34, 56
 sum of y = 102
+array len=3, first element=12
 
 the array length can be read but not changed
 x(-1) is 3

--- a/Test/array.ts
+++ b/Test/array.ts
@@ -42,11 +42,20 @@ print "sum of y = ", sum
 # array name with no parens returns the address (pointer)
 # this is exactly what we need to pass to C functions
 
+# print "address of x = ", x
+# don't actually print the address in this test becase it is always different
+
+
 # tinyscript cannot pass variables to script functions by reference, only value
 # so, passing an array to a script function just passes the address
 
-# print "address of x = ", x
-# don't actually print the address in this test becase it is always different
+func array_info(a){
+	# convert the variable to an array (raises an error if not a valid array)
+	array a
+	print "array len=", a(-1), ", first element=", a(0)
+}
+array_info(y)
+
 
 # example C function to consume a pointer to a tinyscript array
 # element zero is the length, which must not be changed

--- a/tinyscript.c
+++ b/tinyscript.c
@@ -1,12 +1,3 @@
-#define PRINTTOKEN(r) {\
-    outcstr("Token['");\
-    outchar(r & 0xff);\
-    outcstr("' ");\
-    PrintNumber(r);\
-    outcstr("] = ");\
-    PrintString(token);\
-    outchar('\n');}
-
 /* Tinyscript interpreter
  *
  * Copyright 2016-2021 Total Spectrum Software Inc.

--- a/tinyscript.c
+++ b/tinyscript.c
@@ -1029,7 +1029,7 @@ ParseArrayDef(int saveStrings)
     }
 
     if (saveStrings) {
-        name = DupString(token);
+        name = DupString(name);
     }
     if (c != '(') {
         return SyntaxError();


### PR DESCRIPTION
This PR adds the ability to pass an array to a function. It accomplishes this by converting the passed variable to an array. Simply redeclare the variable as an array. See this code fragment from the test script:
```
func array_info(a){
	array a
	...
```
Checking is done to make sure that the redefined variable's value is a valid array address.

The syntax is a bit unusual, but it is easy to understand, takes very little code, and is confined to the #ifdef protected ParseArrayDef function. A more traditional syntax would require a lot of changes to the existing function calling code.